### PR TITLE
Build .tar.gz package for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ deploy:
   file:
     - build/dist/SHA256SUM
     - build/dist/*.zip
+    - build/dist/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads.html) 0.10+
-* [Go](https://golang.org/doc/install) 1.9+
 
-## Build
+## Install
+
+Install latest release version from GitHub to the terraform [third-party plugins](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) directory:
+
+  mkdir -p ~/.terraform.d/plugins && curl -L https://gh-releases.kontena.io/kontena/terraform-provider-kontena/gz/latest | tar -C ~/.terraform.d/plugins xzv
+
+## Development
 
     go get github.com/kontena/terraform-provider-kontena
 
-## Setup
+### Requirements
+
+* [Go](https://golang.org/doc/install) 1.9+
+
+### Setup
 
 See [Installing a Plugin](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) from the Terraform docs:
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -12,6 +12,7 @@ go build -o build/dist/terraform-provider-${PROVIDER}_v${VERSION} .
 ( cd build/dist
 
   zip terraform-provider-${PROVIDER}_${VERSION}_${ARCH}.zip terraform-provider-${PROVIDER}_v${VERSION}
+  tar -czvf terraform-provider-${PROVIDER}_${VERSION}_${ARCH}.tar.gz terraform-provider-${PROVIDER}_v${VERSION}
 
-  sha256sum *.zip > SHA256SUM
+  sha256sum *.tar.gz *.zip > SHA256SUM
 )


### PR DESCRIPTION
Because .zip packages are impossible to install with a `curl ... | ...` oneliner?