### PR TITLE
Enable resource imports

### DIFF
--- a/docs/resource_external_registry.md
+++ b/docs/resource_external_registry.md
@@ -43,3 +43,9 @@ kontena_external_registry.test:
   url = https://kontena-images.example.com
   username = test
 ```
+
+## Importing
+
+Existing `kontena_external_registry` resources can be imported using `terraform import kontena_external_registry.NAME <grid>/<name>`: `terraform import kontena_external_registry.test test/images.example.com`
+
+When importing, the `password` argument can be left as an empty string (`password = ""`). Otherwise terraform will forcibly re-create the resource to ensure that the password matches, because it cannot be read back from the API.

--- a/docs/resource_kontena_grid.md
+++ b/docs/resource_kontena_grid.md
@@ -48,3 +48,7 @@ kontena_grid.grid:
   token = Gc...
   trusted_subnets.# = 0
 ```
+
+## Importing
+
+Existing `kontena_grid` resources can be imported using `terraform import kontena_grid.NAME <grid>`: `terraform import kontena_grid.test test`

--- a/docs/resource_kontena_node.md
+++ b/docs/resource_kontena_node.md
@@ -79,3 +79,7 @@ module.digitalocean-node1.kontena_node.node:
   public_ip = 207.154.200.134
   token = cNr...343g==
 ```
+
+## Importing
+
+Existing `kontena_node` resources can be imported using `terraform import kontena_node.NAME <grid>/<name>`: `terraform import kontena_node.node-1 test/node-1`

--- a/kontena/resource_kontena_external_registry.go
+++ b/kontena/resource_kontena_external_registry.go
@@ -2,6 +2,7 @@ package kontena
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kontena/kontena-client-go/api"
@@ -54,7 +55,22 @@ func resourceKontenaExternalRegistry() *schema.Resource {
 	}
 }
 
+// TODO: this should be api.ExternalRegistryID.Grid
+func parseKontenaExternalRegistryID(id string) (grid, name string) {
+	parts := strings.Split(id, "/")
+
+	// XXX: errors?
+	return parts[0], parts[1]
+}
+
 func setKontenaExternalRegistry(rd *schema.ResourceData, externalRegistry api.ExternalRegistry) {
+	grid, _ := parseKontenaExternalRegistryID(rd.Id())
+
+	rd.Set("grid", grid)
+	rd.Set("url", externalRegistry.URL)
+	rd.Set("username", externalRegistry.Username)
+	rd.Set("email", externalRegistry.Email)
+
 	rd.Set("name", externalRegistry.Name)
 }
 

--- a/kontena/resource_kontena_external_registry.go
+++ b/kontena/resource_kontena_external_registry.go
@@ -48,6 +48,9 @@ func resourceKontenaExternalRegistry() *schema.Resource {
 		Create: resourceKontenaExternalRegistryCreate,
 		Read:   resourceKontenaExternalRegistryRead,
 		Delete: resourceKontenaExternalRegistryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/kontena/resource_kontena_grid.go
+++ b/kontena/resource_kontena_grid.go
@@ -59,6 +59,9 @@ func resourceKontenaGrid() *schema.Resource {
 		Read:   resourceKontenaGridRead,
 		Update: resourceKontenaGridUpdate,
 		Delete: resourceKontenaGridDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/kontena/resource_kontena_node.go
+++ b/kontena/resource_kontena_node.go
@@ -91,6 +91,9 @@ func resourceKontenaNode() *schema.Resource {
 		Read:   resourceKontenaNodeRead,
 		Update: resourceKontenaNodeUpdate,
 		Delete: resourceKontenaNodeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes #13

Allow importing `kontena_grid` and `kontena_node` resources using the existing ID-only refresh logic.

## Testing
Testing against a Kontena Cloud Platform

```
variable "kontena_url" {
}

variable "kontena_token" {

}
variable "kontena_grid" {

}

provider "kontena" {
    url = "${var.kontena_url}"
    token = "${var.kontena_token}"
}
resource "kontena_grid" "demo" {
    name = "${var.kontena_grid}"
    initial_size = 3
    trusted_subnets = [ "192.168.66.0/24" ]
}

output "kontena_grid_token" {
    value = "${kontena_grid.demo.token}"
}
```

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + kontena_grid.demo
      id:                <computed>
      initial_size:      "3"
      name:              "demo-3"
      subnet:            <computed>
      supernet:          <computed>
      token:             <computed>
      trusted_subnets.#: "1"
      trusted_subnets.0: "192.168.66.0/24"

  + kontena_node.node-1
      id:                <computed>
      agent_version:     <computed>
      docker_version:    <computed>
      grid:              "demo-3"
      initial_node:      <computed>
      labels.#:          <computed>
      name:              "billowing-sun-0728"
      node_id:           <computed>
      node_number:       <computed>
      overlay_ip:        <computed>
      private_ip:        <computed>
      public_ip:         <computed>
      token:             <computed>


Plan: 2 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```

```
$ terraform import kontena_grid.demo demo-3
kontena_grid.demo: Importing from ID "demo-3"...
kontena_grid.demo: Import complete!
  Imported kontena_grid (ID: demo-3)
kontena_grid.demo: Refreshing state... (ID: demo-3)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

```
$ terraform import kontena_node.node-1 demo-3/billowing-sun-0728
kontena_node.node-1: Importing from ID "demo-3/billowing-sun-0728"...
kontena_node.node-1: Import complete!
  Imported kontena_node (ID: demo-3/billowing-sun-0728)
kontena_node.node-1: Refreshing state... (ID: demo-3/billowing-sun-0728)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

```
$ kontena grid trusted-subnet list
Warning: Server version is 1.4.3. You are using CLI version 1.5.0.dev.
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

kontena_grid.demo: Refreshing state... (ID: demo-3)
kontena_node.node-1: Refreshing state... (ID: demo-3/billowing-sun-0728)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ kontena_grid.demo
      trusted_subnets.#: "0" => "1"
      trusted_subnets.0: "" => "192.168.66.0/24"


Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```

```
$ terraform apply
kontena_grid.demo: Refreshing state... (ID: demo-3)
kontena_node.node-1: Refreshing state... (ID: demo-3/billowing-sun-0728)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ kontena_grid.demo
      trusted_subnets.#: "0" => "1"
      trusted_subnets.0: "" => "192.168.66.0/24"


Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

kontena_grid.demo: Modifying... (ID: demo-3)
  trusted_subnets.#: "0" => "1"
  trusted_subnets.0: "" => "192.168.66.0/24"
kontena_grid.demo: Modifications complete after 1s (ID: demo-3)

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

kontena_grid_token = k9...ug==
$ kontena grid trusted-subnet list
192.168.66.0/24
Warning: Server version is 1.4.3. You are using CLI version 1.5.0.dev.
