### PR TITLE
Update kontena-client-go for better validations

### DIFF
--- a/kontena/resource_kontena_grid.go
+++ b/kontena/resource_kontena_grid.go
@@ -18,7 +18,8 @@ func resourceKontenaGrid() *schema.Resource {
 			},
 			"initial_size": &schema.Schema{
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"token": &schema.Schema{

--- a/kontena/resource_kontena_grid.go
+++ b/kontena/resource_kontena_grid.go
@@ -68,8 +68,17 @@ func resourceKontenaGrid() *schema.Resource {
 
 func makeKontenaGridCreateParams(rd *schema.ResourceData) api.GridPOST {
 	var gridParams = api.GridPOST{
-		Name:        rd.Get("name").(string),
-		InitialSize: rd.Get("initial_size").(int),
+		Name: rd.Get("name").(string),
+	}
+
+	if value, ok := rd.GetOk("initial_size"); ok {
+		var initialSize = value.(int)
+
+		gridParams.InitialSize = initialSize
+	} else {
+		// computed default
+		// the zero-value will end up POSTing with { "initial_size": 0 }, which fails...
+		gridParams.InitialSize = 1
 	}
 
 	if value, ok := rd.GetOk("token"); ok {

--- a/kontena/resource_kontena_node.go
+++ b/kontena/resource_kontena_node.go
@@ -100,7 +100,7 @@ func resourceKontenaNode() *schema.Resource {
 func setKontenaNode(rd *schema.ResourceData, node api.Node) {
 	rd.Set("grid", node.Grid.Name)
 	rd.Set("name", node.Name)
-	rd.Set("id", node.ID)
+	rd.Set("id", node.ID.String())
 	rd.Set("node_id", node.NodeID)
 	rd.Set("labels", node.Labels)
 
@@ -125,7 +125,7 @@ func getKontenaNodeLabels(rd *schema.ResourceData) *api.NodeLabels {
 
 // Get and sync node token from API
 func readKontenaNodeToken(providerMeta *providerMeta, rd *schema.ResourceData) error {
-	if nodeID, err := client.ParseNodeID(rd.Id()); err != nil {
+	if nodeID, err := api.ParseNodeID(rd.Id()); err != nil {
 		return fmt.Errorf("Invalid node ID %#v: %v", rd.Id(), err)
 
 	} else if nodeToken, err := providerMeta.client.Nodes.GetToken(nodeID); err == nil {
@@ -163,11 +163,9 @@ func resourceKontenaNodeCreate(rd *schema.ResourceData, meta interface{}) error 
 	if node, err := providerMeta.client.Nodes.Create(gridName, nodeParams); err != nil {
 		return fmt.Errorf("Node create: %v", err)
 
-	} else if nodeID, err := client.ParseNodeID(node.ID); err != nil {
-		return fmt.Errorf("Invalid nodeID %v: %v", node.ID, err)
-
 	} else {
-		rd.SetId(nodeID.String())
+		rd.SetId(node.ID.String())
+
 		setKontenaNode(rd, node)
 	}
 
@@ -181,7 +179,7 @@ func resourceKontenaNodeCreate(rd *schema.ResourceData, meta interface{}) error 
 func resourceKontenaNodeRead(rd *schema.ResourceData, meta interface{}) error {
 	var providerMeta = meta.(*providerMeta)
 
-	if nodeID, err := client.ParseNodeID(rd.Id()); err != nil {
+	if nodeID, err := api.ParseNodeID(rd.Id()); err != nil {
 		return fmt.Errorf("Invalid node ID %#v: %v", rd.Id(), err)
 
 	} else if node, err := providerMeta.client.Nodes.Get(nodeID); err == nil {
@@ -218,7 +216,7 @@ func resourceKontenaNodeUpdate(rd *schema.ResourceData, meta interface{}) error 
 
 	providerMeta.logger.Infof("Node %v: Update %#v", rd.Id(), nodeParams)
 
-	if nodeID, err := client.ParseNodeID(rd.Id()); err != nil {
+	if nodeID, err := api.ParseNodeID(rd.Id()); err != nil {
 		return fmt.Errorf("Invalid node ID %#v: %v", rd.Id(), err)
 	} else if node, err := providerMeta.client.Nodes.Update(nodeID, nodeParams); err != nil {
 		return err
@@ -234,7 +232,7 @@ func resourceKontenaNodeDelete(rd *schema.ResourceData, meta interface{}) error 
 
 	providerMeta.logger.Infof("Node %v: Delete", rd.Id())
 
-	if nodeID, err := client.ParseNodeID(rd.Id()); err != nil {
+	if nodeID, err := api.ParseNodeID(rd.Id()); err != nil {
 		return fmt.Errorf("Invalid node ID %#v: %v", rd.Id(), err)
 	} else if err := providerMeta.client.Nodes.Delete(nodeID); err != nil {
 		return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -607,16 +607,16 @@
 		{
 			"checksumSHA1": "Dt3pWibVuXiOt1MvWY8jHb8MqBQ=",
 			"path": "github.com/kontena/kontena-client-go/api",
-			"revision": "4dfd5c13757693f079d28c4b6931d68f300702bd",
-			"revisionTime": "2018-02-12T09:49:12Z",
+			"revision": "8ca5d7a03d27cd51f85895a6580bad62cfae9bdb",
+			"revisionTime": "2018-02-12T11:15:24Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "0dAm6g1nLyGrHEyqyI0X844l5zY=",
+			"checksumSHA1": "O4bSJBoDhj2rfCSvIMH+tfdVQqo=",
 			"path": "github.com/kontena/kontena-client-go/client",
-			"revision": "4dfd5c13757693f079d28c4b6931d68f300702bd",
-			"revisionTime": "2018-02-12T09:49:12Z",
+			"revision": "8ca5d7a03d27cd51f85895a6580bad62cfae9bdb",
+			"revisionTime": "2018-02-12T11:15:24Z",
 			"version": "master",
 			"versionExact": "master"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -605,18 +605,18 @@
 			"revisionTime": "2018-02-02T18:17:30Z"
 		},
 		{
-			"checksumSHA1": "uQ9b0rYXxcuCjE2p0fdMUiUaKC0=",
+			"checksumSHA1": "Dt3pWibVuXiOt1MvWY8jHb8MqBQ=",
 			"path": "github.com/kontena/kontena-client-go/api",
-			"revision": "b9a6adb037dd851abdd0a4272f056b65fbd85040",
-			"revisionTime": "2018-02-06T20:11:26Z",
+			"revision": "4dfd5c13757693f079d28c4b6931d68f300702bd",
+			"revisionTime": "2018-02-12T09:49:12Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "S9eXhChnB5SEpGf83HNW4PDYwuI=",
+			"checksumSHA1": "0dAm6g1nLyGrHEyqyI0X844l5zY=",
 			"path": "github.com/kontena/kontena-client-go/client",
-			"revision": "b9a6adb037dd851abdd0a4272f056b65fbd85040",
-			"revisionTime": "2018-02-06T20:11:26Z",
+			"revision": "4dfd5c13757693f079d28c4b6931d68f300702bd",
+			"revisionTime": "2018-02-12T09:49:12Z",
 			"version": "master",
 			"versionExact": "master"
 		},


### PR DESCRIPTION
* Bump `github.com/kontena/kontena-client-go`
* Update for `api.NodeID` changes
* Validate `provider "kontena" { url = ... }` is non-empty
* Relax `resource "kontena_grid" { initial_size = ... }` to be optional
* Validate node, external_registry IDs for imports using `api.ParseNodeID(...)`